### PR TITLE
change MathFunctions to be a shared library

### DIFF
--- a/src/MathFunctions/CMakeLists.txt
+++ b/src/MathFunctions/CMakeLists.txt
@@ -1,7 +1,7 @@
 # generate SqrtTable.h which is required by MathFunctions
 include(MakeSqrtTable.cmake)
 
-add_library(MathFunctions MathFunctions.cpp mysqrt.cpp SqrtTable.h)
+add_library(MathFunctions SHARED MathFunctions.cpp mysqrt.cpp SqrtTable.h)
 
 # state that anybody linking to us needs to include the current source dir
 # to find MathFunctions.h, while MathFunctions itself doesn't


### PR DESCRIPTION
change MathFunctions to be a shared library.

Debugging works fine when switching build type to Debug.